### PR TITLE
Use the same table tag in order to keep class, id, cellspacing, cellpadd...

### DIFF
--- a/stickyheader.jquery.js
+++ b/stickyheader.jquery.js
@@ -2,7 +2,7 @@ $(document).ready(function () {
 	var tables = $('table.stickyHeader');
 	tables.each(function(i){
 		var table = tables[i];
-		var table = $(table).clone(true).empty();
+		var tableClone = $(table).clone(true).empty();
 		var theadClone = $(table).find('thead').clone(true);
 		var stickyHeader =  $('<div></div>').addClass('stickyHeader hide');
 		stickyHeader.append(tableClone).find('table').append(theadClone);


### PR DESCRIPTION
...ing

This solves an issue with having cellpadding and cellspacing erased from the sticky header.
