### PR TITLE
separate reading and writing of cell widths to prevent layout thrashing

### DIFF
--- a/stickyheader.dojo.js
+++ b/stickyheader.dojo.js
@@ -21,7 +21,9 @@ dojo.addOnLoad(window, function(){
 		
 		var stickyHeaderCells = dojo.query(stickyHeader).query('th');
 		dojo.style(stickyHeader[0],'width', tableWidth + 'px');
-		for (i=0; i<headerCells.length; i++) {
+
+		var cellWidths = [];
+		for (var i = 0, l = headerCells.length; i < l; i++) {
 			var headerCell = headerCells[i];
 			var paddingLeft = dojo.style(headerCell,'padding-left');
 			var paddingRight = dojo.style(headerCell,'padding-right');
@@ -33,7 +35,11 @@ dojo.addOnLoad(window, function(){
 			var cellWidth = width - paddingLeft - paddingRight - borderLeft - borderRight;
 			cellWidth = cellWidth + "px";
 			document.title = "cellwidth: " + cellWidth + "; width: " + width + "; paddingLeft: " + paddingLeft + "; paddingRight: " + paddingRight + "; borderLeft: " + borderLeft + "; borderRight: " + borderRight;
-			dojo.style(stickyHeaderCells[i],'width', cellWidth);
+			cellWidths[i] = cellWidth;
+		}
+
+		for (var i = 0, l = headerCells.length; i < l; i++) {
+			dojo.style(stickyHeaderCells[i],'width', cellWidths[i]);
 		}
 		
 		var cutoffTop = dojo.coords(table, 'includeScroll').t

--- a/stickyheader.jquery.js
+++ b/stickyheader.jquery.js
@@ -21,11 +21,12 @@ $(document).ready(function () {
 		
 		var stickyHeaderCells = stickyHeader.find('th');
 		stickyHeader.css('width', tableWidth);
-		
-		for (i=0; i<headerCells.length; i++) {
-			var headerCell = $(headerCells[i]);
-			var cellWidth = headerCell.width();
-			$(stickyHeaderCells[i]).css('width', cellWidth);
+		var cellWidths = [];
+		for (var i = 0, l = headerCells.length; i < l; i++) {
+			cellWidths[i] = $(headerCells[i]).width();
+		}
+		for (var i = 0, l = headerCells.length; i < l; i++) {
+			$(stickyHeaderCells[i]).css('width', cellWidths[i]);
 		}
 		
 		var cutoffTop = $(table).offset().top;

--- a/stickyheader.mootools.js
+++ b/stickyheader.mootools.js
@@ -21,8 +21,9 @@ window.addEvent('domready', function() {
 		
 		var stickyHeaderCells = stickyHeader.getElements('th');
 		stickyHeader.setStyle('width', tableWidth);
-		
-		for (i=0; i<headerCells.length; i++) {
+
+		var cellWidths = [];
+		for (var i = 0, l = headerCells.length; i < l; i++) {
 			var headerCell = headerCells[i]
 			var paddingLeft = headerCell.getStyle('padding-left').toInt();
 			var paddingRight = headerCell.getStyle('padding-right').toInt();
@@ -34,8 +35,13 @@ window.addEvent('domready', function() {
 			var cellWidth = width + paddingLeft + paddingRight + borderLeft + borderRight;
 			cellWidth = cellWidth + "px";
 			document.title = "cellwidth: " + cellWidth + "; width: " + width + "; paddingLeft: " + paddingLeft + "; paddingRight: " + paddingRight + "; borderLeft: " + borderLeft + "; borderRight: " + borderRight;
-			stickyHeaderCells[i].setStyle('width', cellWidth);
+			cellWidths[i] = cellWidth;
 		}
+		
+		for (var i = 0, l = headerCells.length; i < l; i++) {
+			stickyHeaderCells[i].setStyle('width', cellWidths[i]);
+		}
+
 		var cutoffTop = table.getCoordinates().top;
 		var cutoffBottom = tableHeight + cutoffTop - headerCellHeight;
 		

--- a/stickyheader.prototype.js
+++ b/stickyheader.prototype.js
@@ -18,7 +18,8 @@ Event.observe(window,'load',function() {
 		var stickyHeaderCells = stickyHeader.select('th')
 		stickyHeader.style.width = tableWidth + 'px';
 
-		for (i=0; i<headerCells.length; i++) {
+		var cellWidths = [];
+		for (var i = 0, l = headerCells.length; i < l; i++) {
 			var paddingLeft = headerCells[i].getStyle('padding-left').replace(/px/ig,"");
 			var paddingRight = headerCells[i].getStyle('padding-right').replace(/px/ig,"");
 			var borderLeft = headerCells[i].getStyle('border-left-width').replace(/px/ig,"");
@@ -29,8 +30,11 @@ Event.observe(window,'load',function() {
 			var cellWidth = width - paddingLeft - paddingRight - borderLeft - borderRight;
 			document.title = "cellwidth: " + cellWidth + "; width: " + width + "; paddingLeft: " + paddingLeft + "; paddingRight: " + paddingRight + "; borderLeft: " + borderLeft + "; borderRight: " + borderRight;
 			cellWidth = cellWidth + "px";
-			stickyHeaderCells[i].setStyle({'width':cellWidth});
+			cellWidths[i] = cellWidth;
+		}
 
+		for (var i = 0, l = headerCells.length; i < l; i++) {
+			stickyHeaderCells[i].setStyle({ 'width': cellWidths[i] });
 		}
 
 		var cutoffTop = table.cumulativeOffset()[1];


### PR DESCRIPTION
Reading and writing the widths of the cells in one loop will cause [poor performance](http://kellegous.com/j/2013/01/26/layout-performance/) on large tables with many columns.
